### PR TITLE
Update web-interceptor.js

### DIFF
--- a/lib/api/interceptors/web-interceptor.js
+++ b/lib/api/interceptors/web-interceptor.js
@@ -54,7 +54,7 @@ class WebInterceptor {
 
   getMatchingMock(mocks, request) {
     for (let mock of mocks) {
-      if (mock.matches(request)) {
+      if (mock.matches(request) && mock.isActive) {
         return mock;
       }
     }


### PR DESCRIPTION
Fixing getMatchingMock method so that it returns a matching mock only if it's active